### PR TITLE
DisplaySystem, a class template to help with Swapchain recreation

### DIFF
--- a/include/magma/CreateInfo.hpp
+++ b/include/magma/CreateInfo.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <tuple>
+#include <utility>
+
 namespace magma
 {
   template<class T>

--- a/include/magma/DisplaySystem.hpp
+++ b/include/magma/DisplaySystem.hpp
@@ -1,0 +1,134 @@
+#pragma once
+
+#include <memory>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+
+#include "magma/VulkanHandler.hpp"
+#include "magma/Device.hpp"
+#include "magma/Swapchain.hpp"
+#include "magma/CommandBuffer.hpp"
+#include "magma/Semaphore.hpp"
+#include "magma/ImageView.hpp"
+#include "magma/CreateInfo.hpp"
+
+namespace magma {
+  template<class UserData, class SwapchainUserData, class FrameUserData>
+  class DisplaySystem
+  {
+  private:
+    struct FrameData
+    {
+      magma::ImageView<> swapchainImageView;
+      FrameUserData userData;
+
+      FrameData(magma::Device<claws::no_delete> device, magma::Swapchain<claws::no_delete> swapchain, UserData const &userData, SwapchainUserData const &swapchainUserData, vk::Image swapchainImage)
+	: swapchainImageView(device.createImageView({},
+						    swapchainImage,
+						    vk::ImageViewType::e2D,
+						    swapchain.getFormat(),
+						    {vk::ComponentSwizzle::eIdentity,
+							vk::ComponentSwizzle::eIdentity,
+							vk::ComponentSwizzle::eIdentity,
+							vk::ComponentSwizzle::eIdentity},
+						    {vk::ImageAspectFlagBits::eColor, 0, 1, 0, 1}))
+	, userData(device, swapchain, userData, swapchainUserData, swapchainImageView)
+      {
+      }	
+    };
+
+    vk::PhysicalDevice physicalDevice;
+    magma::Surface<claws::no_delete> surface;
+    magma::Device<claws::no_delete> device;
+    vk::Queue queue;
+  public:
+    UserData userData;
+  private:
+    magma::Swapchain<> swapchain;
+  public:
+    SwapchainUserData swapchainUserData;
+  private:
+    std::vector<FrameData> frames;
+
+  public:
+    DisplaySystem(DisplaySystem const &) = delete;
+    DisplaySystem(DisplaySystem &&) = delete;
+
+    explicit DisplaySystem(vk::PhysicalDevice physicalDevice,
+			   magma::Surface<claws::no_delete> surface,
+			   magma::Device<claws::no_delete> device,
+			   vk::Queue queue,
+			   uint32_t queueFamilyIndex)
+      : physicalDevice(physicalDevice)
+      , surface(surface)
+      , device(device)
+      , queue(queue)
+      , userData(device, physicalDevice, queueFamilyIndex)
+    {
+      recreateSwapchain();
+    }
+
+    void recreateSwapchain()
+    {
+      swapchain = magma::Swapchain<>(surface, device, physicalDevice, swapchain);
+      device.waitIdle();
+      auto const &swapchainImages(swapchain.getImages());
+      swapchainUserData = SwapchainUserData(device, swapchain, userData, static_cast<uint32_t>(swapchainImages.size()));
+
+      frames.clear();
+      frames.reserve(swapchainImages.size());
+
+      for (uint32_t i(0u); i < swapchainImages.size(); ++i)
+	{
+	  frames.emplace_back(device, swapchain, userData, swapchainUserData, swapchainImages[i]);
+	}
+    }
+
+    std::pair<uint32_t, FrameUserData &>  getImage(magma::Semaphore<claws::no_delete> toBeSignaled)
+    {
+    retry:
+      auto[result, index] = swapchain.getImageIndex(toBeSignaled, ~0ul, nullptr);
+
+      switch (result)
+	{
+	case vk::Result::eSuccess:
+	case vk::Result::eSuboptimalKHR:
+	  break;
+	case vk::Result::eErrorOutOfDateKHR:
+	  recreateSwapchain();
+	  goto retry;
+	default:
+	  throw std::runtime_error("Problem occurred during swap chain image acquisition!");
+	};
+      return {index, frames[index].userData};
+    }
+
+    void presentImage(magma::Semaphore<claws::no_delete> wait, uint32_t index)
+    {
+      VkPresentInfoKHR presentInfoRaw(magma::StructBuilder<vk::PresentInfoKHR>::make
+				      (magma::asListRef(wait), magma::asListRef(swapchain.raw()), &index, nullptr));
+      switch (vk::Result(vkQueuePresentKHR(queue, &presentInfoRaw)))
+	{
+	case vk::Result::eSuccess:
+	  break;
+	case vk::Result::eSuboptimalKHR:
+	case vk::Result::eErrorOutOfDateKHR:
+	  recreateSwapchain();
+	  break;
+	default:
+	  throw std::runtime_error("Problem occurred during image presentation!");
+	}
+    }
+
+    magma::Swapchain<claws::no_delete> getSwapchain()
+    {
+      return swapchain;
+    }
+
+    ~DisplaySystem()
+    {
+      device.waitIdle();
+    }
+  };
+}

--- a/include/magma/Surface.hpp
+++ b/include/magma/Surface.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <claws/handle_types.hpp>
+
 namespace magma
 {
   namespace impl
@@ -43,4 +45,9 @@ namespace magma
   
   template<class Deleter = impl::SurfaceDeleter>
   using Surface = claws::handle<impl::Surface, Deleter>;
+
+  Surface<> makeSurface(magma::Instance const &instance, vk::SurfaceKHR vkSurface)
+  {
+    return Surface<>{{instance.vkInstance}, vkSurface};
+  }
 }

--- a/include/magma/Surface.hpp
+++ b/include/magma/Surface.hpp
@@ -2,33 +2,45 @@
 
 namespace magma
 {
-  class Surface
+  namespace impl
   {
-  public:
-    vk::Instance instance;
-    vk::SurfaceKHR vkSurface;
-
-    Surface()
-      : instance(nullptr)
-      , vkSurface(nullptr)
-    {}
-
-    Surface(Instance const &instance, vk::SurfaceKHR vkSurface)
-      : instance(instance.vkInstance)
-      , vkSurface(vkSurface)
-    {}
-
-    Surface(Surface const &) = delete;
-
-    ~Surface()
+    class Surface
     {
-      if (instance)
-        instance.destroySurfaceKHR(vkSurface);
-    }
+    public:
+      vk::SurfaceKHR vkSurface;
 
-    bool isQueueFamilySuitable(vk::PhysicalDevice physicalDevice, uint32_t queueIndex) const
+      Surface() = default;
+
+      Surface(vk::SurfaceKHR vkSurface) noexcept
+	: vkSurface(vkSurface)
+      {}
+
+      ~Surface() = default;
+
+      bool isQueueFamilySuitable(vk::PhysicalDevice physicalDevice, uint32_t queueIndex) const
+      {
+	return physicalDevice.getSurfaceSupportKHR(queueIndex, vkSurface);
+      }
+    };
+
+    class SurfaceDeleter
     {
-      return physicalDevice.getSurfaceSupportKHR(queueIndex, vkSurface);
-    }
-  };
+      vk::Instance instance;
+
+    public:
+      SurfaceDeleter(vk::Instance instance) noexcept
+	: instance(instance)
+      {
+      }
+
+      void operator()(Surface surface)
+      {
+	if (instance)
+	  instance.destroySurfaceKHR(surface.vkSurface);
+      }
+    };
+  }
+  
+  template<class Deleter = impl::SurfaceDeleter>
+  using Surface = claws::handle<impl::Surface, Deleter>;
 }

--- a/include/magma/VulkanHandler.hpp
+++ b/include/magma/VulkanHandler.hpp
@@ -55,7 +55,7 @@ namespace magma
     /// @return a `std::pair` of the select `vk::PhysicalDevice` and the corresponding biggest value returned by mapToScore.
     /// @throw Any exception thrown by `mapToScore`, or by vulkan-hpp through `enumeratePhysicalDevices`.
     template<class SCORE_MAPPER>
-    auto selectDevice(SCORE_MAPPER mapToScore)
+    auto selectDevice(SCORE_MAPPER mapToScore) const
     {
       auto physicalDevices(vkInstance.enumeratePhysicalDevices());
 
@@ -78,7 +78,7 @@ namespace magma
     }
 
     template<class DEVICE_FILTER, class COMPARE>
-    vk::PhysicalDevice selectDevice(DEVICE_FILTER deviceFilter, COMPARE compare)
+    vk::PhysicalDevice selectDevice(DEVICE_FILTER deviceFilter, COMPARE compare) const
     {
       auto physicalDevices(vkInstance.enumeratePhysicalDevices());
       auto end(std::remove_if(physicalDevices.begin(), physicalDevices.end(), [deviceFilter](auto &&a) { return !deviceFilter(a); }));
@@ -90,7 +90,7 @@ namespace magma
     }
 
     template<class FILTER, class COMPARE>
-    std::pair<vk::PhysicalDevice, unsigned int> selectQueue(FILTER filter, COMPARE compare)
+    std::pair<vk::PhysicalDevice, unsigned int> selectQueue(FILTER filter, COMPARE compare) const
     {
       auto physicalDevices(vkInstance.enumeratePhysicalDevices());
       std::vector<std::tuple<vk::QueueFamilyProperties, vk::PhysicalDevice, unsigned int>> queueList;
@@ -163,8 +163,6 @@ namespace magma
     {
       other.vkInstance = nullptr;
     }
-
-
 
     ~Instance()
     {


### PR DESCRIPTION
`magma::DisplaySystem` is a class to help with sawpchain, recreation and handling userData associated with frames.
It automatically (re)calls constructors of the different userdata provided.
It is undocumented for the moment, and this design isn't final, this pull request is mostly for reviews.

Also:
- made magma::Instance movable
- fixed `magma::CommandPool` destructor (resources weren't released), and fixed constness on some members
- made surface be a `claws::handle_type` (breaking change)
- moved some includes (with the goal to make files more self-contained)

These other changes are rather minor, but where needed.
Please do not merge his pull request before monday, I want to see how it works on https://github.com/raven-os/feathers first and refine it.
Reviews and ideas are welcome.