### PR TITLE
Added `makeCreateInfo` and `makeCreateInfoNoFlags`

### DIFF
--- a/modules/magma/CreateInfo.hpp
+++ b/modules/magma/CreateInfo.hpp
@@ -80,6 +80,41 @@ namespace magma
     }
   };
 
+  ///
+  /// \brief Constructs a CreateInfo struct using the given arguments
+  ///
+  /// If present, `stype` and `pnext` are auto-filled by vulkan-hpp, and should not be given
+  /// Lists are automaticly decomposed into a (size, pointer) pair
+  /// Supported list types are:
+  /// - std::array
+  /// - std::vector
+  /// - magma::SingleValListRef (should be created using asListRef)
+  /// - magma::EmptyList (passes (0, nullptr))
+  ///
+  template<class CreateInfo, class... T>
+  constexpr CreateInfo makeCreateInfo(T &&... args)
+  {
+    return StructBuilder<CreateInfo>::make(std::forward<T>(args)...);
+  }
+
+  ///
+  /// \brief Constructs a CreateInfo struct using the given arguments
+  ///
+  /// If present, `stype` and `pnext` are auto-filled by vulkan-hpp, and should not be given
+  /// `flags` is set to `{}` (aka 0 in the C API) contrary to `magma::makeCreateInfo`
+  /// Lists are automaticly decomposed into a (size, pointer) pair
+  /// Supported list types are:
+  /// - std::array
+  /// - std::vector
+  /// - magma::SingleValListRef (should be created using asListRef)
+  /// - magma::EmptyList (passes (0, nullptr))
+  ///
+  template<class CreateInfo, class... T>
+  constexpr CreateInfo makeCreateInfoNoFlags(T &&... args)
+  {
+    return StructBuilder<CreateInfo, true>::make(std::forward<T>(args)...);
+  }
+
   template<class T>
   constexpr auto asListRef(T const &val) noexcept
   {


### PR DESCRIPTION
This takes advantage of function partial specialization to simplify the API.
Code was tested using wasted_prophecies and is confirmed to work.
I'd be for deprecating usage of the struct above, and removing or moving it to
to `magma::impl` once feathers no longer depends on it.

Some documentation was also added for the 2 new functions.